### PR TITLE
Don't allow 'shell' prompts to be selected

### DIFF
--- a/css/getting-started.css
+++ b/css/getting-started.css
@@ -56,6 +56,10 @@ code {
 
 code-blue {
     color: var(--color-blue-d);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 p.large.step {


### PR DESCRIPTION
The first thing I did on seeing the instructions was try to copy them... which got the annoying `$` prompts in them!

`user-select: none` avoids the dollar signs themselves from being selected.